### PR TITLE
chore: add stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,66 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+# daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+# daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+# exemptLabels:
+#  - backlog
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+# markComment: >
+#  This issue has been automatically marked as stale because it has not had
+#  recent activity. It will be closed if no further activity occurs. Thank you
+#  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 15
+  daysUntilClose: 7
+  markComment: >
+    This pull request has been automatically marked as stale.
+    It will be closed if no further activity occurs.
+    Thank you for your contributions.
+
+issues:
+  daysUntilStale: 30
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale.
+    It will be closed if no further activity occurs.
+    Thank you for your contributions.
+ exemptLabels:
+   - backlog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add the stale-bot configuration file

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->

## Motivation and Context
This will be added to clean the issues and PR, which are opened and were lost in the sands of time.

If an issue is not commented on or passed on triage for more than 30days it gets a message that is about to close in 7days.
If the issue has no interaction after that is closed.

If a PR is made and has no interaction in 15 days it gets a message that is about to close in 7 days.
If the PR has no interaction after that is closed.